### PR TITLE
Corrected syntax to prevent compile warning.

### DIFF
--- a/EnhancedNativeTrainer/main.cpp
+++ b/EnhancedNativeTrainer/main.cpp
@@ -11,7 +11,7 @@ https://github.com/gtav-ent/GTAV-EnhancedNativeTrainer
 #include "inc\main.h"
 #include "script.h"
 #include "keyboard.h"
-#include "config_io.h";
+#include "config_io.h"
 
 BOOL APIENTRY DllMain(HMODULE hInstance, DWORD reason, LPVOID lpReserved)
 {


### PR DESCRIPTION
main.cpp(14): warning C4067: unexpected tokens following preprocessor directive - expected a newline