### PR TITLE
Rewritten engine power feature

### DIFF
--- a/EnhancedNativeTrainer/src/features/teleportation.cpp
+++ b/EnhancedNativeTrainer/src/features/teleportation.cpp
@@ -397,6 +397,7 @@ void teleport_to_last_vehicle()
 	if (ENTITY::DOES_ENTITY_EXIST(veh))
 	{
 		PED::SET_PED_INTO_VEHICLE(PLAYER::PLAYER_PED_ID(), veh, -1);
+		set_old_vehicle_state(false); // set old vehicle state to false since we changed cars but didn't actually exit the last one
 		if (VEHICLE::IS_THIS_MODEL_A_HELI(ENTITY::GET_ENTITY_MODEL(veh)) || VEHICLE::IS_THIS_MODEL_A_PLANE(ENTITY::GET_ENTITY_MODEL(veh)))
 		{
 			VEHICLE::SET_HELI_BLADES_FULL_SPEED(PED::GET_VEHICLE_PED_IS_USING(PLAYER::PLAYER_PED_ID()));
@@ -485,6 +486,7 @@ void get_chauffeur_to_marker()
 	upgradeVehMaximum(veh);
 
 	PED::SET_PED_INTO_VEHICLE(ped, veh, -1);
+	set_old_vehicle_state(false); // set old vehicle state to false since we changed cars but didn't actually exit the last one
 
 	for (int i = 0; i <= 8; i++) {
 		if (VEHICLE::IS_VEHICLE_SEAT_FREE(veh, i)) {

--- a/EnhancedNativeTrainer/src/features/vehicles.h
+++ b/EnhancedNativeTrainer/src/features/vehicles.h
@@ -123,6 +123,12 @@ int get_current_veh_invincibility_mode();
 
 void onchange_veh_invincibility_mode(int value, SelectFromListMenuItem* source);
 
+int get_current_veh_eng_pow_index();
+
+void onchange_veh_eng_pow_index(int value, SelectFromListMenuItem* source);
+
+void set_old_vehicle_state(bool updatedState);
+
 MenuItemImage* vehicle_image_preview_finder(MenuItem<std::string> choice);
 
 void init_vehicle_feature();
@@ -180,3 +186,5 @@ bool inline is_this_a_heli_or_plane(Vehicle veh)
 	Entity et = ENTITY::GET_ENTITY_MODEL(veh);
 	return VEHICLE::IS_THIS_MODEL_A_HELI(et) || VEHICLE::IS_THIS_MODEL_A_PLANE(et);
 }
+
+bool did_player_just_enter_vehicle(Ped playerPed);

--- a/EnhancedNativeTrainer/src/ui_support/menu_functions.cpp
+++ b/EnhancedNativeTrainer/src/ui_support/menu_functions.cpp
@@ -202,13 +202,6 @@ void draw_menu_from_struct_def(StandardOrToggleMenuDef defs[], int lineCount, in
 			item->value = i;
 			menuItems.push_back(item);
 		}
-		else if (defs[i].itemType != NULL && defs[i].itemType == RPM)
-		{
-			RpmItem<int> *item = new RpmItem<int>();
-			item->caption = defs[i].text;
-			item->value = i;
-			menuItems.push_back(item);
-		}
 		else if (defs[i].itemType != NULL && defs[i].itemType == WANTED)
 		{
 			WantedSymbolItem *item = new WantedSymbolItem();
@@ -360,38 +353,6 @@ void CashItem<T>::handleRightPress()
 
 	if (cash > max)
 		cash = min;
-}
-
-template<class T>
-bool RpmItem<T>::onConfirm()
-{
-	Vehicle veh = PED::GET_VEHICLE_PED_IS_USING(PLAYER::PLAYER_PED_ID());
-	BOOL bPlayerExists = ENTITY::DOES_ENTITY_EXIST(PLAYER::PLAYER_PED_ID());
-	if (bPlayerExists && PED::IS_PED_IN_ANY_VEHICLE(PLAYER::PLAYER_PED_ID(), true))
-	{
-		VEHICLE::_SET_VEHICLE_ENGINE_TORQUE_MULTIPLIER(veh, 1.8f);
-		VEHICLE::_SET_VEHICLE_ENGINE_POWER_MULTIPLIER(veh, rpm);
-	}
-	set_status_text("Engine Power Modified");
-	return true;
-}
-
-template<class T>
-void RpmItem<T>::handleLeftPress()
-{
-	rpm -= rpmIncrement;
-
-	if (rpm < rpmMin)
-		rpm = rpmMax;
-}
-
-template<class T>
-void RpmItem<T>::handleRightPress()
-{
-	rpm += rpmIncrement;
-
-	if (rpm > rpmMax)
-		rpm = rpmMin;
 }
 
 int WantedSymbolItem::get_wanted_value()

--- a/EnhancedNativeTrainer/src/ui_support/menu_functions.h
+++ b/EnhancedNativeTrainer/src/ui_support/menu_functions.h
@@ -183,25 +183,7 @@ public:
 	int GetCash() { return cash; }
 };
 
-template<class T>
-class RpmItem : public MenuItem <T>
-{
-	virtual ~RpmItem() {}
-
-	int rpm = 0;
-	int rpmIncrement = 25;
-	int rpmMin = 0;
-	int rpmMax = 400;
-	virtual bool onConfirm();
-	virtual bool isAbsorbingLeftAndRightEvents() { return true; };
-	virtual void handleLeftPress();
-	virtual void handleRightPress();
-
-public:
-	int GetRpm() { return rpm; }
-};
-
-enum MenuItemType { STANDARD, TOGGLE, CASH, WANTED, RPM };
+enum MenuItemType { STANDARD, TOGGLE, CASH, WANTED };
 
 struct StandardOrToggleMenuDef {
 	std::string text;
@@ -540,32 +522,6 @@ void draw_menu_item_line(MenuItem<T> *item, float lineWidth, float lineHeight, f
 
 		std::stringstream ss;
 		ss << "<C>~HUD_COLOUR_GREYLIGHT~&lt;&lt; ~HUD_COLOUR_PURE_WHITE~" << std::string("$") << commaCash << " ~HUD_COLOUR_GREYLIGHT~&gt;&gt;</C>";
-		auto ssStr = ss.str();
-		UI::_ADD_TEXT_COMPONENT_STRING((char *)ssStr.c_str());
-		UI::_DRAW_TEXT(0, textY);
-	}
-	else if (RpmItem<T>* rpmItem = dynamic_cast<RpmItem<T>*>(item))
-	{
-		UI::SET_TEXT_FONT(font);
-		UI::SET_TEXT_SCALE(0.0, text_scale);
-		UI::SET_TEXT_COLOUR(255, 255, 255, 255);
-		UI::SET_TEXT_RIGHT_JUSTIFY(1);
-
-		UI::SET_TEXT_OUTLINE();
-
-		if (dropShadow)
-		{
-			UI::SET_TEXT_DROPSHADOW(5, 0, 78, 255, 255);
-		}
-
-		UI::SET_TEXT_EDGE(0, 0, 0, 0, 0);
-		UI::SET_TEXT_WRAP(0.0f, lineLeftScaled + lineWidthScaled - leftMarginScaled);
-		UI::_SET_TEXT_ENTRY("STRING");
-
-		std::string commaRpm = std::to_string(rpmItem->GetRpm());
-
-		std::stringstream ss;
-		ss << "<C>~HUD_COLOUR_GREYLIGHT~&lt;&lt; ~HUD_COLOUR_PURE_WHITE~" << commaRpm << " ~HUD_COLOUR_GREYLIGHT~&gt;&gt;</C>";
 		auto ssStr = ss.str();
 		UI::_ADD_TEXT_COMPONENT_STRING((char *)ssStr.c_str());
 		UI::_DRAW_TEXT(0, textY);


### PR DESCRIPTION
## FOR YOUR REVIEW
- Setting now takes effect immediately without having to confirm, as per
  other "list menu" style behaviour, also applied immediately while in a
  vehicle
- Setting is saved to db and restored upon startup
- Reused SelectFromListMenuItem, removed RPM-related classes to maximize
  code reuse
- Setting applies only when we've changed the modifier, spawned into a
  new vehicle, or exited/entered vehicles normally
- Credits to dannysimms for the initial idea and implementation
